### PR TITLE
Add state to allow consumers to remove unused side-effect-free mod…

### DIFF
--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -30,12 +30,15 @@ module.exports = Analyzer;
 
 // Public API
 
-Analyzer.prototype.run = function run(ast, resource) {
+Analyzer.prototype.run = function run(ast, resource, options) {
   this.requireUses = new Set();
   this.exportsUses = new Set();
   this.moduleUses = new Map();
 
   const current = this.getModule(resource);
+  if (options && options.sideEffects === false) {
+    current.sideEffects = false;
+  }
 
   this.gather(ast, current);
   this.sift(ast, current);

--- a/lib/shake/analyzer.js
+++ b/lib/shake/analyzer.js
@@ -146,6 +146,8 @@ Analyzer.prototype.gather = function gather(ast, current) {
     const name = shake.evaluateConst(node.init.arguments[0]);
     const module = this.getUnresolvedModule(current.resource, name);
 
+    current.addRequire(name, node.init);
+
     // Destructuring
     if (node.id.type === 'ObjectPattern') {
       this.gatherDestructured(module, node.id, current);

--- a/lib/shake/module.js
+++ b/lib/shake/module.js
@@ -4,6 +4,7 @@ const debug = require('debug')('common-shake:module');
 
 function Module(resource) {
   this.resource = resource;
+  this.sideEffects = true;
   this.bailouts = false;
   this.issuers = new Set();
   this.uses = new Map();
@@ -58,6 +59,7 @@ Module.prototype.getInfo = function getInfo() {
   this.compute();
 
   return {
+    removeImport: !this.sideEffects && this.uses.size === 0,
     bailouts: this.bailouts,
     declarations: this.declarations.map(decl => decl.name),
     uses: Array.from(this.uses.keys())

--- a/lib/shake/module.js
+++ b/lib/shake/module.js
@@ -25,7 +25,7 @@ Module.prototype.addRequire = function addRequire(name, node) {
     this.requireNodes.set(name, []);
   }
   this.requireNodes.get(name).push(node);
-}
+};
 
 Module.prototype.forceExport = function forceExport() {
   this.forced = true;

--- a/lib/shake/module.js
+++ b/lib/shake/module.js
@@ -9,6 +9,7 @@ function Module(resource) {
   this.issuers = new Set();
   this.uses = new Map();
   this.declarations = [];
+  this.requireNodes = new Map();
 
   this.dependentUses = [];
   this.pendingUses = [];
@@ -18,6 +19,13 @@ function Module(resource) {
 module.exports = Module;
 
 // Public API
+
+Module.prototype.addRequire = function addRequire(name, node) {
+  if (!this.requireNodes.has(name)) {
+    this.requireNodes.set(name, []);
+  }
+  this.requireNodes.get(name).push(node);
+}
 
 Module.prototype.forceExport = function forceExport() {
   this.forced = true;


### PR DESCRIPTION
A module can be marked as side-effect-free by passing `{ sideEffects: false }` to `analyzer.run()`.

The require calls for a side-effect-free module can be found by doing `issuer.requireNodes.get(depName)`.

Do `module.getInfo().removeImport` to check if a module can be entirely removed.